### PR TITLE
fix: ignore index equals used for reduced diff comparison.

### DIFF
--- a/diffuzzer/src/fuzzing/objective/trace.rs
+++ b/diffuzzer/src/fuzzing/objective/trace.rs
@@ -25,7 +25,7 @@ impl TraceObjective {
         for i in 0..fst_trace.rows.len() {
             let fst_row = fst_trace.rows[i].clone();
             let snd_row = snd_trace.rows[i].clone();
-            if !fst_row.ignore_index_equal(&snd_row) {
+            if fst_row != snd_row {
                 trace_diff.push(TraceRowIsDifferent {
                     fst: fst_row,
                     snd: snd_row,


### PR DESCRIPTION
ignore_index_equal used for reduced diff comparison. However, "same_diff" method used for this purpose now. Method TraceObjective.diff used for fuzzing and there is no need to ignore indexes in this case